### PR TITLE
Fix: `q-input` Auto-Growing Textarea: Dynamic `line-height`…

### DIFF
--- a/ui/src/components/input/QInput.sass
+++ b/ui/src/components/input/QInput.sass
@@ -13,7 +13,7 @@
     bottom: 2px
 
   .q-field__native, .q-field__prefix, .q-field__suffix
-    line-height: 18px
+    line-height: 1;
 
   .q-field__native
     resize: vertical


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

**The PR fulfills these requirements:**

This commit updates the CSS of the `q-input` auto-growing textarea. It replaces a fixed pixel value for `line-height` with a relative value based on the font size. This change ensures that the line spacing remains proportional and consistent regardless of the font size set, enhancing readability and user experience. Previously, the fixed pixel value could lead to visual inconsistencies when the font size was adjusted.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
